### PR TITLE
Require auth for /metrics

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -33,6 +33,7 @@ shim:
   authenticated: true
   authenticated-endpoints:
     - /v1/chat/completions
+    - /metrics
   paths:
     - /v1/chat/completions
     - /metrics


### PR DESCRIPTION
Adds /metrics to the shim's authenticated endpoints so vLLM metrics are no longer publicly scrapeable; Prometheus and the router's overload poller authenticate with an admin key. Deploy after tinfoilsh/controlplane#499 — the current validate-key would reject the admin key and break scraping.