### PR TITLE
feat: expose authenticated token counting

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -33,8 +33,10 @@ shim:
   authenticated: true
   authenticated-endpoints:
     - /v1/chat/completions
+    - /tokenize
     - /metrics
   paths:
     - /v1/chat/completions
+    - /tokenize
     - /metrics
     - /health


### PR DESCRIPTION
## Summary
- allow authenticated `/tokenize` requests through the enclave shim
- enable model-router input-token counting from tinfoilsh/confidential-model-router#447