### PR TITLE
Update cvmimage v0.11.0 attestation-v3 release stack

### DIFF
--- a/.github/workflows/tinfoil-release-publish.yml
+++ b/.github/workflows/tinfoil-release-publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Measure image, attest, and publish the release
-        uses: tinfoilsh/measure-image-action@e9967c4a2dd60bacc7cce9e4315c5ebcd46118e9 # v0.9.2
+        uses: tinfoilsh/measure-image-action@ca4cfa35773897455c9e51409d61c75b8e377c27 # v0.10.2
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-cvm-version: 0.10.4
+cvm-version: 0.11.0
 cpus: 16
 memory: 65536
 gpus: 1


### PR DESCRIPTION
## Summary
- update `cvm-version` to `0.11.0`
- pin the release publisher to `tinfoilsh/measure-image-action@v0.10.2`

## Why
This moves the production model release path onto the qualified cvmimage v0.11.0 attestation-v3 stack and the matching measurement/freshness workflow.

## Validation
- parsed `tinfoil-config.yml` and the publish workflow as YAML
- verified only the config version and action pin changed
- `git diff --check`

Merging this PR does not publish a release; the repository's normal release workflow remains the rollout gate.
